### PR TITLE
docs: sync main branch ruleset

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,3 +25,15 @@
 ## rollout/rollback 영향
 
 -
+
+## CLEVER PR review completion
+
+- target branch: `dev` / `main`
+- context docs checked:
+- PR 정보를 wiki에 올리지 않는다.
+- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
+- wiki/service context update result: `updated` / `not-needed`
+- service doc update:
+- wiki update:
+- clever-context-monorepo update:
+- linked issue close evidence:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,17 @@ Use this repository for:
 - rollout and rollback trace
 - release evidence linkage
 
+## Main Branch Contract
+
+This repository is public and its `main` branch is protected by the GitHub
+ruleset `CLEVER protect main`.
+
+- Do not push directly to `main`.
+- Use a role-prefixed branch for repository changes.
+- Open a PR into `main`.
+- `main` PRs require at least one approval.
+- Admin bypass is allowed only in `pull_request` mode.
+
 Do not treat this repository as:
 
 - the default generic startup surface

--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --
 - 전사 규칙의 정본 문서
 - 서버 배포 방법이나 운영 절차 상세
 
+## main 브랜치 운영 규칙
+
+이 repo는 public으로 운영하며, `main`은 GitHub ruleset `CLEVER protect main`으로 보호한다.
+
+- `main` direct push 금지
+- `main` 삭제 금지
+- force push 금지
+- `main` 변경은 PR 필수
+- PR 승인 1명 이상 필수
+- admin bypass는 `pull_request` 모드만 허용
+
+이 저장소 자체를 수정할 때도 역할 접두사 branch에서 작업하고 PR로 올린다.
+
 ## project-start root 규칙
 
 모든 작업의 시작점은 `project-start` root issue다.


### PR DESCRIPTION
## change id

- not-issued: control-plane ruleset sync and PR flow verification

## 관련 issue

- none

## 대상 repo/service

- `clever-change-control`
- control-plane approval and traceability documentation

## 변경 내용

- Document the current public `main` protection contract.
- Add the `main` branch contract to `AGENTS.md`.
- Add CLEVER PR review completion fields to the actual PR template.

## companion PRs

- https://github.com/EVNSolution/clever-agent-project/pull/3
- https://github.com/EVNSolution/clever-context-monorepo/pull/4

## 테스트 여부

- `git push origin HEAD:main` rejected with `GH013` and `Changes must be made through a pull request`.
- `git diff --check`

## 검수 포인트

- Branch name uses the role prefix `docs/`.
- `main` direct push is blocked.
- PR body carries the review-agent completion fields.

## rollout/rollback 영향

- docs/template only
- no runtime or deployment impact

## CLEVER PR review completion

- target branch: `main`
- context docs checked: `README.md`, `AGENTS.md`, `.github/PULL_REQUEST_TEMPLATE.md`, sibling `clever-context-monorepo/docs/root/doc-governance.md`
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: `not-needed`
- wiki update: `not-needed`
- clever-context-monorepo update: https://github.com/EVNSolution/clever-context-monorepo/pull/4
- linked issue close evidence: no linked issue for this ruleset smoke test
