### PR TITLE
docs: set main PR approvals to zero

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,8 @@ ruleset `CLEVER protect main`.
 - Do not push directly to `main`.
 - Use a role-prefixed branch for repository changes.
 - Open a PR into `main`.
-- `main` PRs require at least one approval.
+- `main` requires a PR but does not require approving reviews.
+- Merge/write access is limited to repository admins.
 - Admin bypass is allowed only in `pull_request` mode.
 
 Do not treat this repository as:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --
 - `main` 삭제 금지
 - force push 금지
 - `main` 변경은 PR 필수
-- PR 승인 1명 이상 필수
+- PR 필수지만 승인 수는 0명
+- merge/write는 repo admin 권한자만 수행
 - admin bypass는 `pull_request` 모드만 허용
 
 이 저장소 자체를 수정할 때도 역할 접두사 branch에서 작업하고 PR로 올린다.


### PR DESCRIPTION
## change id

- not-issued: control-plane ruleset operation update

## 관련 issue

- none

## 대상 repo/service

- `clever-change-control`
- control-plane approval and traceability documentation

## 변경 내용

- Update the documented `main` policy from one required reviewer to zero required approving reviews.
- Keep PR-required, direct-push-blocked, admin-only merge/write operating language.

## companion PRs

- https://github.com/EVNSolution/clever-agent-project/pull/4
- https://github.com/EVNSolution/clever-context-monorepo/pull/5

## 테스트 여부

- `git diff --check`
- remote ruleset check -> `required_approving_review_count: 0`

## 검수 포인트

- `main` still requires PR.
- Required approving reviewers is 0.
- Repo access is constrained by admin/write permissions, not self-review.

## rollout/rollback 영향

- docs only
- no runtime or deployment impact

## CLEVER PR review completion

- target branch: `main`
- context docs checked: `README.md`, `AGENTS.md`
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: `not-needed`
- wiki update: `not-needed`
- clever-context-monorepo update: https://github.com/EVNSolution/clever-context-monorepo/pull/5
- linked issue close evidence: no linked issue for this ruleset operation update
