### PR TITLE
docs: add PR merge title standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,21 @@ ruleset `CLEVER protect main`.
 - Merge/write access is limited to repository admins.
 - Admin bypass is allowed only in `pull_request` mode.
 
+## PR Merge Commit Title Contract
+
+When merging a PR into `main`, make the resulting main commit visibly PR-based.
+Use squash merge and set the merge subject explicitly:
+
+```bash
+gh pr merge <pr-number> --squash \
+  --subject "PR-MERGE <owner>/<repo>#<pr-number>: <pr-title>" \
+  --body-file <merge-body-file>
+```
+
+Merge body should include the merge summary, validation evidence, and
+wiki/service context update result. Do not use a plain feature/doc commit title
+as the main merge commit subject.
+
 Do not treat this repository as:
 
 - the default generic startup surface

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --
 - merge/write는 repo admin 권한자만 수행
 - admin bypass는 `pull_request` 모드만 허용
 
+`main` merge commit 제목은 PR merge임이 드러나게 아래 형식을 쓴다.
+
+```text
+PR-MERGE <owner>/<repo>#<pr-number>: <pr-title>
+```
+
 이 저장소 자체를 수정할 때도 역할 접두사 branch에서 작업하고 PR로 올린다.
 
 ## project-start root 규칙


### PR DESCRIPTION
## change id

- not-issued: control-plane merge title standard

## 관련 issue

- none

## 대상 repo/service

- `clever-change-control`
- control-plane approval and traceability documentation

## 변경 내용

- Add the PR merge commit title contract.
- Standardize main merge subject format as `PR-MERGE <owner>/<repo>#<pr-number>: <pr-title>`.
- Document merge body requirements.

## companion PRs

- https://github.com/EVNSolution/clever-agent-project/pull/5
- https://github.com/EVNSolution/clever-context-monorepo/pull/6

## 테스트 여부

- `git diff --check`

## 검수 포인트

- Main merge commit should visibly look like a PR merge.
- The merge subject should include repo and PR number.

## rollout/rollback 영향

- docs only
- no runtime or deployment impact

## CLEVER PR review completion

- target branch: `main`
- context docs checked: `AGENTS.md`, `README.md`
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: `not-needed`
- wiki update: `not-needed`
- clever-context-monorepo update: https://github.com/EVNSolution/clever-context-monorepo/pull/6
- linked issue close evidence: no linked issue for this merge-title standard update
