### PR TITLE
docs: add concurrent work gate

### DIFF
--- a/.github/ISSUE_TEMPLATE/change-request.yml
+++ b/.github/ISSUE_TEMPLATE/change-request.yml
@@ -19,6 +19,20 @@ body:
   - type: markdown
     attributes:
       value: |
+        ## Concurrent Work Gate
+
+        구현 시작 전과 PR merge 전에는 target repo issue와 clever-change-control issue를 같이 확인한다.
+
+        parallel work decision 값:
+        - `done`: 관련 작업이 이미 merged/closed PR로 끝남
+        - `blocked`: 진행 중인 issue, branch, open PR과 범위가 겹침
+        - `allowed-with-non-overlap`: 진행 중인 작업은 있으나 범위가 겹치지 않음
+        - `user-forced-proceed`: 사용자가 `완전 무시모드`, `강제 진행`, `user-forced-proceed`를 명시함
+
+        `user-forced-proceed`는 사용자 강제 진행 기록이다. conflict candidates와 merge risk를 남긴다.
+  - type: markdown
+    attributes:
+      value: |
         template 기반 작업이면 issue body에 아래 메타를 같이 남긴다.
 
         ```text
@@ -82,6 +96,33 @@ body:
     attributes:
       label: 제약
       placeholder: 일정, 범위, 의존성, 제외 조건을 작성한다.
+    validations:
+      required: true
+  - type: dropdown
+    id: parallel-work-decision
+    attributes:
+      label: parallel work decision
+      description: Concurrent Work Gate 판정값이다.
+      options:
+        - done
+        - blocked
+        - allowed-with-non-overlap
+        - user-forced-proceed
+    validations:
+      required: true
+  - type: textarea
+    id: conflict-candidates
+    attributes:
+      label: conflict candidates
+      description: target repo issue, clever-change-control issue, active branch, open PR 확인 결과를 적는다. user-forced-proceed이면 사용자 강제 진행 사유도 적는다.
+      placeholder: |
+        target repo issue:
+        clever-change-control issue:
+        open PR:
+        active branch:
+        conflict candidates:
+        merge risk:
+        user-forced-proceed reason:
     validations:
       required: true
   - type: dropdown

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,6 +26,15 @@
 
 -
 
+## Concurrent Work Gate
+
+- parallel work decision: `done` / `blocked` / `allowed-with-non-overlap` / `user-forced-proceed`
+- target repo issue:
+- clever-change-control issue:
+- open PR checked:
+- conflict candidates:
+- user-forced-proceed reason:
+
 ## CLEVER PR review completion
 
 - target branch: `dev` / `main`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,34 @@ Use `fixes`, `closes`, or similar GitHub keywords only when the PR merge is
 intended to close the referenced issue. Use plain issue mentions for context
 links.
 
+## Concurrent Work Gate
+
+For target-repository development, this repository must record the parallel work
+decision before implementation and before PR merge.
+
+Required fields in the relevant project-start or change-request issue:
+
+- `parallel work decision`: `done`, `blocked`, `allowed-with-non-overlap`, or
+  `user-forced-proceed`
+- `target repo issue`
+- `clever-change-control issue`
+- `open PR` candidates checked
+- `conflict candidates`
+- `user-forced-proceed reason`, when the user requests 완전 무시모드 or 강제 진행
+
+Decision meanings:
+
+- `done`: the related target repo issue already has a merged or closed PR and no
+  active follow-up branch.
+- `blocked`: an active issue, branch, or open PR overlaps the target service,
+  API, data, deploy, or file scope.
+- `allowed-with-non-overlap`: active parallel work exists, but the agent records
+  why the issue-level scope does not overlap.
+- `user-forced-proceed`: 사용자 강제 진행. The agent does not treat concurrent
+  issue, branch, or open PR overlap as a blocker after the user explicitly
+  requests this mode. The issue must still record conflict candidates and known
+  merge risk.
+
 ## Read Order For Repo-Local Work
 
 When the task is specifically about this repository, read in this order:


### PR DESCRIPTION
## change id

- not-issued: control-plane concurrent work gate

## 관련 issue

- none

## 대상 repo/service

- `clever-change-control`
- traceability rules, change-request issue template, PR template

## 변경 내용

- Add Concurrent Work Gate recording requirements to `AGENTS.md`.
- Add `parallel work decision` and `conflict candidates` to the change-request issue form.
- Add PR template fields for parallel work decision and conflict candidates.

## companion PRs

- https://github.com/EVNSolution/clever-agent-project/pull/6
- https://github.com/EVNSolution/clever-context-monorepo/pull/7

## 테스트 여부

- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/ISSUE_TEMPLATE/change-request.yml')"`
- covered by companion clever-agent-project test suite

## 검수 포인트

- change-control issue records `done`, `blocked`, `allowed-with-non-overlap`, or `user-forced-proceed`.
- user-forced-proceed is recorded as 사용자 강제 진행.

## rollout/rollback 영향

- docs/templates only
- no runtime or deployment impact

## Concurrent Work Gate

- parallel work decision: `allowed-with-non-overlap`
- target repo issue: none for control-plane doc update
- clever-change-control issue: none for control-plane doc update
- open PR checked: companion PRs only
- conflict candidates: none; each PR writes separate control-plane repo files
- user-forced-proceed reason: not used

## CLEVER PR review completion

- target branch: `main`
- context docs checked: `AGENTS.md`, `.github/ISSUE_TEMPLATE/change-request.yml`, `.github/PULL_REQUEST_TEMPLATE.md`
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: `not-needed`
- wiki update: `not-needed`
- clever-context-monorepo update: https://github.com/EVNSolution/clever-context-monorepo/pull/7
- linked issue close evidence: no linked issue for this control-plane doc update
