### PR TITLE
docs: use default merge pull request title

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,17 +70,18 @@ ruleset `CLEVER protect main`.
 ## PR Merge Commit Title Contract
 
 When merging a PR into `main`, make the resulting main commit visibly PR-based.
-Use squash merge and set the merge subject explicitly:
+Use the GitHub default-style merge subject. If the agent uses squash merge,
+set the subject explicitly:
 
 ```bash
 gh pr merge <pr-number> --squash \
-  --subject "PR-MERGE <owner>/<repo>#<pr-number>: <pr-title>" \
+  --subject "Merge pull request #<pr-number> from <owner>/<source-branch>" \
   --body-file <merge-body-file>
 ```
 
-Merge body should include the merge summary, validation evidence, and
-wiki/service context update result. Do not use a plain feature/doc commit title
-as the main merge commit subject.
+Merge body should start with the PR title, then include the merge summary,
+validation evidence, and wiki/service context update result. Do not use a plain
+feature/doc commit title as the main merge commit subject.
 
 Do not treat this repository as:
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --
 `main` merge commit 제목은 PR merge임이 드러나게 아래 형식을 쓴다.
 
 ```text
-PR-MERGE <owner>/<repo>#<pr-number>: <pr-title>
+Merge pull request #<pr-number> from <owner>/<source-branch>
 ```
 
 이 저장소 자체를 수정할 때도 역할 접두사 branch에서 작업하고 PR로 올린다.


### PR DESCRIPTION
## change id

- not-issued: control-plane merge title adjustment

## 관련 issue

- none

## 대상 repo/service

- `clever-change-control`
- merge title operating contract

## 변경 내용

- Replace the custom `PR-MERGE` subject standard with the GitHub default-style `Merge pull request #<pr-number> from <owner>/<source-branch>` subject.

## 테스트 여부

- `git diff --check`
- covered by companion clever-agent-project test suite

## 검수 포인트

- The merge subject starts like GitHub's default merge commit title.
- The PR title is kept in the merge body rather than forced into the subject prefix.

## rollout/rollback 영향

- docs only
- no runtime or deployment impact

## Concurrent Work Gate

- parallel work decision: `allowed-with-non-overlap`
- target repo issue: none for control-plane doc update
- clever-change-control issue: none for control-plane doc update
- open PR checked: companion PRs only
- conflict candidates: none; each PR writes separate control-plane repo files
- user-forced-proceed reason: not used

## CLEVER PR review completion

- target branch: `main`
- context docs checked: `AGENTS.md`, `README.md`
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: `not-needed`
- wiki update: `not-needed`
- clever-context-monorepo update: companion PR will be linked after creation
- linked issue close evidence: no linked issue for this control-plane doc update
