### PR TITLE
docs: align startup preflight gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,19 +27,24 @@ CLEVER expects a local three-repository workspace:
 2. `clever-context-monorepo`
 3. `clever-change-control`
 
-Before doing real work, run the automatic workspace check from the current session:
+Before doing real work, run the automatic preflight check from the current session:
 
 ```bash
-python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --json
+python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 If the session is explicitly about editing this repository itself, run:
 
 ```bash
-python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --current-repo-maintenance --json
+python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
 ```
 
-Interpret `agent_action` like this:
+The preflight must verify `gh auth status`, GitHub login `OziinG`,
+`EVNSolution` org membership, control-plane remotes, clean worktrees, remote
+fetch access, and issue/PR/ruleset read access. If `preflight_check.ready` is
+false, stop before startup work and report the failed checks.
+
+If it is true, interpret `workspace_check.agent_action` like this:
 
 - `proceed-with-hard-gate`: the workspace is complete and startup may continue
 - `current-repo-maintenance`: this repository itself is the target, so stay here

--- a/README.md
+++ b/README.md
@@ -13,19 +13,20 @@
 - 작업 라인과 대상 저장소가 아직 정해지지 않은 일반 시작: `clever-agent-project`
 - 현재 `clever-change-control` 자체를 수정하는 작업: 여기서 계속
 
-시작 전에 먼저 아래 명령으로 로컬 3저장소 상태를 확인한다.
+시작 전에 먼저 아래 명령으로 로컬 3저장소, `gh auth status`, GitHub 계정, org membership, 원격 접근, issue/PR/ruleset 조회 가능 여부를 확인한다.
 
 ```bash
-python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --json
+python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
 ```
 
 현재 저장소 자체를 직접 수정하는 작업이면 아래처럼 유지보수 모드로 확인한다.
 
 ```bash
-python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --workspace-check --current-repo-maintenance --json
+python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
 ```
 
-결과는 아래처럼 해석한다.
+`preflight_check.ready=false`이면 시작 절차로 내려가지 않고 실패한 check를 먼저 해결한다.
+`true`이면 내부 `workspace_check.agent_action`을 아래처럼 해석한다.
 
 - `proceed-with-hard-gate`: 로컬 상태가 정상이며 시작 절차를 진행할 수 있음
 - `current-repo-maintenance`: 현재 저장소 자체를 수정하는 세션이므로 여기서 계속


### PR DESCRIPTION
## 변경 내용
- change-control repo에서 시작할 때도 `--preflight`를 먼저 실행하도록 AGENTS/README 동기화
- `gh auth status`, GitHub login `OziinG`, org membership, remotes, clean worktree, issue/PR/ruleset read access를 시작 전 조건으로 명시
- `preflight_check.ready=false`이면 issue/project-start 단계로 내려가지 않도록 명시

## 검증
- `git diff --check`

## Concurrent Work Gate
- parallel work decision: `allowed-with-non-overlap`
- target repo issue: none
- clever-change-control issue: none
- open PR checked: no open PR used as blocker
- conflict candidates: none in this repo
- user-forced-proceed reason: not used

## CLEVER PR review completion
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: not-needed
- wiki update: not-needed
- clever-context-monorepo update: EVNSolution/clever-context-monorepo#9
- not-needed reason: this PR only aligns change-control startup instructions with the root governance update
