### PR TITLE
docs: add PR scope grouping gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,18 @@
 
 -
 
+## PR Scope Grouping Gate
+
+- grouping decision: `single-pr` / `split-required`
+- same document/operating-rule cleanup:
+- same validation command:
+- different app/service/contract surface:
+- merge order dependency:
+- rollback unit:
+
+같은 issue 안의 같은 운영 문서/절차 정리이고 같은 검증으로 충분하면 `single-pr`로 둔다.
+앱, 서비스, 계약 표면, merge 순서, 롤백 단위가 다르면 `split-required`로 둔다.
+
 ## 테스트 여부
 
 -


### PR DESCRIPTION
## change id

- not assigned

## 관련 issue

- not assigned

## 대상 repo/service

- `EVNSolution/clever-change-control`
- service: control-plane PR template

## 변경 내용

- Add `PR Scope Grouping Gate` fields to the PR template.

## PR Scope Grouping Gate

- grouping decision: `single-pr`
- same document/operating-rule cleanup: yes, PR grouping policy and templates are one operating-rule sync.
- same validation command: yes, workspace doc/template sync is covered by the same pytest and diff-check verification.
- different app/service/contract surface: no product app, service, API, or contract surface changes.
- merge order dependency: none.
- rollback unit: repo-local template only.

## 테스트 여부

- `python3 -m pytest -q` in `clever-agent-project`: 55 passed, 2 skipped
- `git diff --check` in `clever-agent-project`: passed
- `git diff --check` in `clever-context-monorepo`: passed
- `git diff --check` in `clever-change-control`: passed

## 검수 포인트

- PR template now asks for the grouping decision and split criteria.

## rollout/rollback 영향

- No runtime rollout impact.
- Rollback is reverting this template commit.

## Concurrent Work Gate

- parallel work decision: `done`
- target repo issue: not assigned
- clever-change-control issue: not assigned
- open PR checked: none open at creation time
- conflict candidates: none
- user-forced-proceed reason: n/a

## CLEVER PR review completion

- target branch: `main`
- context docs checked: `clever-context-monorepo/docs/root/pipeline-governance.md`
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: not-needed
- wiki update: not-needed
- clever-context-monorepo update: companion branch `docs/pr-scope-grouping-gate`
- linked issue close evidence: not assigned
