### PR TITLE
[일반 개발][변경] startup flow 포인터 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Local OS/editor artifacts.
+.DS_Store
+**/.DS_Store
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,37 +19,19 @@ Short version:
 - generic startup: redirect to `clever-agent-project`
 - repo-local maintenance: stay in `clever-change-control`
 
-## Workspace Contract
+## Startup Pointer
 
-CLEVER expects a local three-repository workspace:
+The startup/preflight authority lives in `clever-agent-project`. Do not duplicate
+the command, GitHub login prompt, preflight checklist, or `workspace_check`
+branch table here.
 
-1. `clever-agent-project`
-2. `clever-context-monorepo`
-3. `clever-change-control`
+For generic CLEVER startup, move to the sibling `clever-agent-project` checkout
+and follow its `AGENTS.md`. The bootstrap helper there reads the complete local
+three-repository workspace, including this repository.
 
-Before doing real work, run the automatic preflight check from the current session:
-
-```bash
-python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --json
-```
-
-If the session is explicitly about editing this repository itself, run:
-
-```bash
-python3 ../clever-agent-project/scripts/bootstrap_clever_work.py --cwd "$PWD" --preflight --current-repo-maintenance --json
-```
-
-The preflight must verify `gh auth status`, GitHub login `OziinG`,
-`EVNSolution` org membership, control-plane remotes, clean worktrees, remote
-fetch access, and issue/PR/ruleset read access. If `preflight_check.ready` is
-false, stop before startup work and report the failed checks.
-
-If it is true, interpret `workspace_check.agent_action` like this:
-
-- `proceed-with-hard-gate`: the workspace is complete and startup may continue
-- `current-repo-maintenance`: this repository itself is the target, so stay here
-- `switch-to-clever-agent-project`: this is generic startup work, so move to `clever-agent-project`
-- `stop-and-fix-workspace`: the local workspace is incomplete, so do not continue as if startup were healthy
+For repo-local maintenance, stay in this repository after the
+`clever-agent-project` preflight identifies this repository as the intended
+control-plane maintenance target.
 
 ## What This Repository Owns
 


### PR DESCRIPTION
## change id

- chg-20260428-001

## 관련 issue

- EVNSolution/clever-change-control#33
- supersedes EVNSolution/clever-change-control#32

## 대상 repo/service

- EVNSolution/clever-change-control
- AGENTS startup pointer and local artifact ignore

## 변경 내용

- copied startup/preflight commands 제거
- startup/preflight authority가 `clever-agent-project`에 있음을 포인터로만 기록
- change-control repo가 approval/traceability ownership에 집중하도록 문서 경계 정리
- `.DS_Store` ignore 추가

## PR Scope Grouping Gate

- grouping decision: `split-required`
- same document/operating-rule cleanup: yes, companion control-plane cleanup
- same validation command: `python3 -m pytest -q` from clever-agent-project
- different app/service/contract surface: yes, separate repository
- merge order dependency: can merge with companion PRs
- rollback unit: this repository's startup pointer docs

## 테스트 여부

- `python3 -m pytest -q` from `clever-agent-project` → `60 passed, 2 skipped`
- `git diff --check` across all three control-plane repos
- sibling startup detail duplicate search passed

## 검수 포인트

- no copied `--preflight`, `CLEVER_EXPECTED_GITHUB_LOGIN`, `gh auth status`, or stale `OziinG` startup details
- pointer directs agents to `clever-agent-project/AGENTS.md`

## rollout/rollback 영향

- rollout: change-control repo docs stop duplicating startup procedure
- rollback: restore copied startup command text, not recommended because it drifts

## Concurrent Work Gate

- parallel work decision: `allowed-with-non-overlap`
- target repo issue: n/a
- clever-change-control issue: EVNSolution/clever-change-control#33
- open PR checked: supersedes EVNSolution/clever-change-control#32
- conflict candidates: none
- user-forced-proceed reason: n/a

## CLEVER PR review completion

- target branch: `main`
- context docs checked: yes
- PR 정보를 wiki에 올리지 않는다.
- 검토 에이전트 작업은 wiki/service context 업데이트로 마친다.
- wiki/service context update result: `not-needed`
- service doc update: not-needed
- wiki update: not-needed
- clever-context-monorepo update: companion PR EVNSolution/clever-context-monorepo#19
- linked issue close evidence: EVNSolution/clever-change-control#33 remains open until companion PRs are resolved
